### PR TITLE
Add upz_stream service for video streaming QoE measurement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
     volumes:
       - 'spd_data:/reports' # Iperf Data
     restart: always
+  upz_stream:
+    build: ./upz_stream
+    volumes:
+      - 'str_data:/app/reports' # Iperf Data
+    restart: always
 
 
 volumes:
@@ -31,3 +36,4 @@ volumes:
   mr_data:
   wm_data:
   spd_data:
+  str_data:

--- a/upz_stream/Dockerfile
+++ b/upz_stream/Dockerfile
@@ -1,0 +1,43 @@
+# Use official Node.js base image
+FROM node:24-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Chromium and required tools (wget for dash.js)
+RUN apt-get update && apt-get install -y \
+    chromium \
+    wget \
+    ca-certificates \
+    cron \
+    cron-daemon-common \
+    vnstat \ 
+    --no-install-recommends && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set Puppeteer executable path
+ENV CHROME_PATH=/usr/bin/chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Create working directories
+WORKDIR /app
+RUN mkdir -p /app/public/lib /app/scripts /app/reports
+
+# Download dash.js into the image during build
+RUN wget https://cdn.dashjs.org/latest/dash.all.min.js -O /app/public/lib/dash.all.min.js
+
+# Copy project files
+COPY public/index.html /app/public/
+COPY puppeteer.js /app/scripts/
+COPY monitor_network_usage.sh /app/scripts/monitor_network_usage.sh
+
+# Initialize npm and install Puppeteer locally
+RUN npm init -y && npm install puppeteer
+
+RUN chmod +x /app/scripts/monitor_network_usage.sh /app/scripts/puppeteer.js \
+    && touch /var/log/cron.log  \
+    && (crontab -l 2>/dev/null; echo "35 * * * * /usr/local/bin/node /app/scripts/puppeteer.js >> /var/log/cron.log 2>&1") | crontab -\
+    && (crontab -l ; echo "55 23 * * * /app/scripts/monitor_network_usage.sh >> /var/log/cron.log 2>&1") | crontab -
+
+# Start cron in foreground via sh -c
+CMD ["sh", "-c", "service vnstat start && cron -f"]
+

--- a/upz_stream/README.md
+++ b/upz_stream/README.md
@@ -1,0 +1,114 @@
+# upz_streaming_qoe_monitor
+
+## 📖 Overview
+
+This container performs **video streaming Quality of Experience (QoE)** measurement using a DASH video player and **network usage monitoring** via `vnStat`.  
+It logs key playback and network metrics into CSV and log files, enabling analysis and correlation between streaming behavior and network conditions.
+
+---
+
+## ⚙️ Setup
+
+1. Clone the repository and navigate to the project directory:
+   ```bash
+   git clone <repository_url>
+   cd <repository_directory>
+   ```
+2. Ensure the following files exist:
+   - `Dockerfile`
+   - `public/index.html` (dash.js-based test player)
+   - `puppeteer.js` (headless browser script for QoE)
+   - `monitor_network_usage.sh` (network stats logger)
+
+---
+
+## 🧪 Streaming QoE Measurement
+
+The script `puppeteer.js` is scheduled via cron to run periodically. It:
+
+1. Launches Chromium headlessly using Puppeteer.
+2. Loads a DASH stream in a `dash.js`-based video player.
+3. Captures key QoE metrics:
+   - Startup delay
+   - Buffering time and events
+   - Stall durations
+   - Bitrate switches
+   - Dropped frames
+   - Playback duration
+   - Buffering ratio
+4. Appends the results to `/app/reports/stream.csv`.
+
+---
+
+## 🌐 Network Usage Monitoring
+
+The script `monitor_network_usage.sh` is also scheduled via cron. It:
+
+1. Ensures `vnStat` is available and the database is initialized.
+2. Logs network usage stats for the interface (default: `eth0`).
+3. Appends results to `/app/reports/network_usage.log`.
+
+---
+
+## 🕒 Cron Jobs
+
+The container currently runs both jobs **once per hour at minute 40**:
+
+| Script                      | Schedule (CRON)       | Output File                             |
+|-----------------------------|------------------------|------------------------------------------|
+| `puppeteer.js`              | `40 * * * *`           | `/app/reports/stream.csv`               |
+| `monitor_network_usage.sh`  | `40 * * * *`           | `/app/reports/network_usage.log`        |
+
+> You can easily adjust the schedule by editing the cron expressions in the Dockerfile.
+
+All output logs from cron are written to `/var/log/cron.log`.
+
+---
+
+## 📁 File Outputs
+
+| File                             | Description                                  |
+|----------------------------------|----------------------------------------------|
+| `/app/reports/stream.csv`        | Streaming QoE results (CSV format)           |
+| `/app/reports/network_usage.log` | Daily network usage log from vnStat          |
+| `/var/log/cron.log`              | Output and error logs from cron jobs         |
+
+---
+
+## 🐳 Running the Container
+
+1. **Build the Docker image**:
+   ```bash
+   docker build -t upz_streaming_qoe_monitor .
+   ```
+
+2. **Run the container**:
+   ```bash
+   docker run -d --name qoe_monitor upz_streaming_qoe_monitor
+   ```
+
+To stop:
+```bash
+docker stop qoe_monitor
+docker rm qoe_monitor
+```
+
+---
+
+## ⚙️ Environment Variables
+
+| Variable                    | Description                                  |
+|-----------------------------|----------------------------------------------|
+| `PUPPETEER_EXECUTABLE_PATH` | Set to `/usr/bin/chromium` in Dockerfile     |
+
+---
+
+## 📦 Dependencies (preinstalled in Dockerfile)
+
+- Node.js
+- Chromium
+- Puppeteer
+- cron
+- vnStat
+
+---

--- a/upz_stream/monitor_network_usage.sh
+++ b/upz_stream/monitor_network_usage.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Interface to monitor
+INTERFACE="eth0"
+
+# Log file location
+LOG_FILE="/app/reports/network_usage.log"
+
+# Check if vnStat is installed
+if ! command -v vnstat &> /dev/null; then
+    echo "vnStat is not installed. Please ensure it is installed in the container."
+    exit 1
+fi
+
+# Initialize vnStat database for the interface if not already initialized
+if ! vnstat --iflist | grep -q "$INTERFACE"; then
+    vnstat  -i $INTERFACE
+    vnstat -i $INTERFACE --create
+fi
+
+# Update vnStat database
+vnstat  -i $INTERFACE
+
+# Record the current network usage
+echo "$(date): Network usage for interface $INTERFACE" >> $LOG_FILE
+vnstat -i $INTERFACE -d >> $LOG_FILE
+echo "---------------------------------" >> $LOG_FILE

--- a/upz_stream/public/index.html
+++ b/upz_stream/public/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>DASH QoE Test</title>
+  <script src="./lib/dash.all.min.js"></script>
+</head>
+<body>
+  <video id="videoPlayer" controls autoplay width="640" height="360"></video>
+
+  <script>
+    const url = "https://dash.akamaized.net/envivio/EnvivioDash3/manifest.mpd";
+    const player = dashjs.MediaPlayer().create();
+    const video = document.querySelector("#videoPlayer");
+
+    window.qoeMetrics = {
+      startupDelay: null,
+      bufferingCount: 0,
+      bufferingTime: 0,
+      stallEvents: [],       // durations of individual stalls
+      bitrateChanges: [],
+      playbackStart: null,
+      playbackEnd: null
+    };
+
+    let startupTimeStart = performance.now();
+    console.log("[INIT] Starting DASH player");
+
+    player.initialize(video, url, false);
+
+    player.on(dashjs.MediaPlayer.events.STREAM_INITIALIZED, () => {
+      console.log("[EVENT] STREAM_INITIALIZED");
+      video.play().then(() => {
+        console.log("[EVENT] video.play() succeeded");
+      }).catch(e => {
+        console.error("[EVENT] video.play() failed", e);
+      });
+    });
+
+    player.on(dashjs.MediaPlayer.events.PLAYBACK_STARTED, () => {
+      const now = performance.now();
+      window.qoeMetrics.startupDelay = (now - startupTimeStart) / 1000;
+      window.qoeMetrics.playbackStart = performance.now();
+      console.log("[EVENT] PLAYBACK_STARTED — Startup Delay:", window.qoeMetrics.startupDelay);
+    });
+
+    player.on(dashjs.MediaPlayer.events.BUFFER_EMPTY, () => {
+      window.qoeMetrics.bufferingStart = performance.now();
+      window.qoeMetrics.bufferingCount += 1;
+      console.log("[EVENT] BUFFER_EMPTY");
+    });
+
+    player.on(dashjs.MediaPlayer.events.BUFFER_LOADED, () => {
+      if (window.qoeMetrics.bufferingStart) {
+        const duration = (performance.now() - window.qoeMetrics.bufferingStart) / 1000;
+        window.qoeMetrics.bufferingTime += duration;
+        window.qoeMetrics.stallEvents.push(duration);
+        delete window.qoeMetrics.bufferingStart;
+        console.log("[EVENT] BUFFER_LOADED");
+      }
+    });
+
+    player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, (e) => {
+      window.qoeMetrics.bitrateChanges.push({
+        time: performance.now() / 1000,
+        qualityIndex: e.newQuality
+      });
+      console.log("[EVENT] QUALITY_CHANGE_RENDERED to", e.newQuality);
+    });
+
+    // Mark end for playback duration measurement
+    player.on(dashjs.MediaPlayer.events.PLAYBACK_ENDED, () => {
+      window.qoeMetrics.playbackEnd = performance.now();
+      console.log("[EVENT] PLAYBACK_ENDED");
+    });
+  </script>
+</body>
+</html>

--- a/upz_stream/puppeteer.js
+++ b/upz_stream/puppeteer.js
@@ -1,0 +1,76 @@
+const puppeteer = require('puppeteer');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: true,
+    executablePath: '/usr/bin/chromium',
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--autoplay-policy=no-user-gesture-required'
+    ]
+  });
+
+  const page = await browser.newPage();
+
+  page.on('console', msg => console.log(`[BROWSER] ${msg.text()}`));
+  page.on('pageerror', err => console.error('[BROWSER ERROR]', err));
+
+  await page.goto('file:///app/public/index.html', { waitUntil: 'load' });
+
+  console.log("[INFO] Waiting 30 seconds for video playback and QoE metrics...");
+  await new Promise(resolve => setTimeout(resolve, 30000));
+
+  const qoe = await page.evaluate(() => {
+    const video = document.querySelector('video');
+    const quality = video.getVideoPlaybackQuality?.() || {};
+    const droppedFrames = quality.droppedVideoFrames || video.webkitDroppedFrameCount || 0;
+    const totalFrames = quality.totalVideoFrames || 0;
+
+    const playbackStart = window.qoeMetrics.playbackStart ?? performance.now();
+    const playbackEnd = window.qoeMetrics.playbackEnd ?? performance.now();
+    const playbackDuration = (playbackEnd - playbackStart) / 1000;
+    const bufferingRatio = window.qoeMetrics.bufferingTime / playbackDuration;
+
+    return {
+      ...window.qoeMetrics,
+      totalStallTime: (window.qoeMetrics.stallEvents || []).reduce((a, b) => a + b, 0),
+      playbackDuration,
+      bufferingRatio,
+      droppedFrames,
+      totalFrames
+    };
+  });
+
+  if (qoe) {
+    console.log('📊 QoE Metrics:', qoe);
+
+    const csvPath = '/app/reports/stream.csv';
+    const timestamp = new Date().toISOString();
+    const row = [
+      timestamp,
+      qoe.startupDelay ?? '',
+      qoe.bufferingCount ?? '',
+      qoe.bufferingTime ?? '',
+      qoe.stallEvents.length ?? '',
+      qoe.totalStallTime.toFixed(2) ?? '',
+      qoe.bitrateChanges.length ?? '',
+      qoe.playbackDuration.toFixed(2) ?? '',
+      qoe.bufferingRatio.toFixed(4) ?? '',
+      qoe.droppedFrames ?? '',
+      qoe.totalFrames ?? ''
+    ].join(',');
+
+    if (!fs.existsSync(csvPath)) {
+      fs.writeFileSync(csvPath, 'Timestamp,StartupDelay,BufferingCount,BufferingTime,StallEvents,TotalStallTime,BitrateSwitches,PlaybackDuration,BufferingRatio,DroppedFrames,TotalFrames\n');
+    }
+
+    fs.appendFileSync(csvPath, row + '\n');
+  } else {
+    console.log('⚠️ QoE Metrics: Not available');
+  }
+
+  await browser.close();
+})();


### PR DESCRIPTION
Introduce a new service for measuring video streaming Quality of Experience (QoE) using a DASH player and network monitoring scripts. Include a Dockerfile, README, and necessary scripts for setup and execution.